### PR TITLE
feat: add patch rewrite system

### DIFF
--- a/packages/core/src/patch.test.ts
+++ b/packages/core/src/patch.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { rewrite } from './rewrite';
+import { state } from './state';
+import { Patch } from './patch';
+import type { Event } from './types';
+
+describe('patch', () => {
+  it('state(history) equals state(rewrite(history))', () => {
+    const history: Event[] = [
+      { type: 'Create', id: 'u1', value: 0 },
+      { type: 'Update', id: 'u1', value: 1 },
+      { type: 'Delete', id: 'u1' },
+      { type: 'Create', id: 'u2', value: 3 },
+      { type: 'Update', id: 'u2', value: 4 },
+    ];
+    expect(state(rewrite(history))).toEqual(state(history));
+  });
+
+  it('compose merges and normalizes', () => {
+    const a: Event[] = [{ type: 'Create', id: 'u1', value: 0 }];
+    const b: Event[] = [
+      { type: 'Update', id: 'u1', value: 1 },
+      { type: 'Create', id: 'u2', value: 2 },
+    ];
+    const p1 = Patch.from(a, rewrite);
+    const p2 = Patch.from(b, rewrite);
+    const composed = p1.compose(p2);
+    expect(composed.toNormalForm()).toEqual(rewrite([...a, ...b]));
+  });
+});

--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -1,0 +1,33 @@
+import type { Event } from './types';
+
+/**
+ * Immutable sequence of events that can be composed and normalized.
+ */
+export class Patch {
+  private constructor(
+    private readonly events: Event[],
+    private readonly rw: (events: readonly Event[]) => Event[],
+  ) {}
+
+  /**
+     * Create a patch from raw events.
+     */
+  static from(events: readonly Event[], rewrite: (events: readonly Event[]) => Event[]): Patch {
+    return new Patch([...events], rewrite);
+  }
+
+  /**
+     * Merge this patch with another and normalize the result.
+     */
+  compose(other: Patch): Patch {
+    const combined = [...this.events, ...other.events];
+    return new Patch(this.rw(combined), this.rw);
+  }
+
+  /**
+     * Return the normalized form of the underlying events.
+     */
+  toNormalForm(): Event[] {
+    return this.rw([...this.events]);
+  }
+}

--- a/packages/core/src/rewrite.property.test.ts
+++ b/packages/core/src/rewrite.property.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import type { Event } from './types';
+import { rewrite } from './rewrite';
+import { state } from './state';
+
+type History = Event[];
+const ids = ['u1', 'u2'];
+const rand = (n: number) => Math.floor(Math.random() * n);
+
+function randomEvent(): Event {
+  const id = ids[rand(ids.length)];
+  const value = rand(5);
+  switch (rand(3)) {
+    case 0:
+      return { type: 'Create', id, value };
+    case 1:
+      return { type: 'Update', id, value };
+    default:
+      return { type: 'Delete', id };
+  }
+}
+
+function randomHistory(): History {
+  const len = rand(7);
+  const h: History = [];
+  for (let i = 0; i < len; i++) h.push(randomEvent());
+  return h;
+}
+
+describe('rewrite property', () => {
+  it('state(events) === state(rewrite(events))', () => {
+    for (let i = 0; i < 50; i++) {
+      const events = randomHistory();
+      expect(state(rewrite(events))).toEqual(state(events));
+    }
+  });
+});

--- a/packages/core/src/rewrite.test.ts
+++ b/packages/core/src/rewrite.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { rewrite } from './rewrite';
+import type { Event } from './types';
+
+describe('rewrite', () => {
+  it('Create→Update→Delete→Create → [Create]', () => {
+    const history: Event[] = [
+      { type: 'Create', id: 'u1', value: 0 },
+      { type: 'Update', id: 'u1', value: 1 },
+      { type: 'Delete', id: 'u1' },
+      { type: 'Create', id: 'u1', value: 2 },
+    ];
+    expect(rewrite(history)).toEqual([
+      { type: 'Create', id: 'u1', value: 2 },
+    ]);
+  });
+
+  it('Update alone → empty', () => {
+    const history: Event[] = [{ type: 'Update', id: 'x', value: 1 }];
+    expect(rewrite(history)).toEqual([]);
+  });
+
+  it('multiple updates collapse to last', () => {
+    const history: Event[] = [
+      { type: 'Create', id: 'u1', value: 0 },
+      { type: 'Update', id: 'u1', value: 1 },
+      { type: 'Update', id: 'u1', value: 2 },
+    ];
+    expect(rewrite(history)).toEqual([
+      { type: 'Create', id: 'u1', value: 0 },
+      { type: 'Update', id: 'u1', value: 2 },
+    ]);
+  });
+});

--- a/packages/core/src/rewrite.ts
+++ b/packages/core/src/rewrite.ts
@@ -1,0 +1,49 @@
+import type { Create, Update, Event, Id } from './types';
+
+interface Hist {
+  create: Create;
+  update?: Update;
+  lastIndex: number;
+}
+
+/**
+ * Normalize a sequence of events.
+ *
+ * Rules:
+ * - L1: `Update` without prior `Create` is discarded.
+ * - L2: `Delete` removes all history for that id.
+ * - L3: `Create→Update*→Delete` collapses to nothing.
+ * - L4: Sequential `Update`s collapse to the last one.
+ */
+export function rewrite(events: readonly Event[]): Event[] {
+  const map = new Map<Id, Hist>();
+  events.forEach((ev, idx) => {
+    switch (ev.type) {
+      case 'Create':
+        map.set(ev.id, { create: ev, lastIndex: idx });
+        break;
+      case 'Update': {
+        const hist = map.get(ev.id);
+        if (hist) {
+          hist.update = ev;
+          hist.lastIndex = idx;
+        }
+        break;
+      }
+      case 'Delete':
+        map.delete(ev.id);
+        break;
+      default: {
+        const _exhaustive: never = ev;
+        void _exhaustive;
+      }
+    }
+  });
+  const items = Array.from(map.values()).sort((a, b) => a.lastIndex - b.lastIndex);
+  const result: Event[] = [];
+  for (const h of items) {
+    result.push(h.create);
+    if (h.update) result.push(h.update);
+  }
+  return result;
+}

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -1,0 +1,26 @@
+import type { Event } from './types';
+
+/**
+ * Replay a sequence of events and return the resulting state.
+ */
+export function state(events: readonly Event[]): Record<string, unknown> {
+  const s: Record<string, unknown> = {};
+  for (const ev of events) {
+    switch (ev.type) {
+      case 'Create':
+        s[ev.id] = ev.value;
+        break;
+      case 'Update':
+        if (ev.id in s) s[ev.id] = ev.value;
+        break;
+      case 'Delete':
+        delete s[ev.id];
+        break;
+      default: {
+        const _exhaustive: never = ev;
+        void _exhaustive;
+      }
+    }
+  }
+  return s;
+}


### PR DESCRIPTION
## Summary
- implement event rewrite function with laws L1-L4
- add Patch abstraction with composition and normalization
- provide state replay helper and property-based tests

## Testing
- `pnpm -C packages/core test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc43a280832f949d3422dd8f93c7